### PR TITLE
chore: Bump lodash from 4.17.15 to 4.17.19

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7458,9 +7458,9 @@ lodash.uniq@^4.5.0:
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
 "lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 log-symbols@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Bump `lodash` from 4.17.15 to 4.17.19. This addresses [CVE-2020-8203](https://github.com/advisories/GHSA-p6mc-m468-83gw).

To patch `lodash` package, temporarily add the following `lodash` dependencies in package.json one at a time:

```
"lodash": ">=3.5 <5"
"lodash": "^4.17.11"
"lodash": "^4.17.13"
"lodash": "^4.17.14"
"lodash": "^4.17.15"
"lodash": "^4.17.5"
```

Each time, run:

```
$ yarn upgrade lodash
```

Then remove `lodash` from package.json.
